### PR TITLE
〜Qiita APIをお試しで呼ぶ処理を実装〜

### DIFF
--- a/lib/api/qiita_repository.dart
+++ b/lib/api/qiita_repository.dart
@@ -1,0 +1,32 @@
+import 'package:dio/dio.dart';
+import 'package:qiita_application/model/person_model.dart';
+import 'package:qiita_application/model/qiita_article.dart';
+
+Future<List<Person>> fetchQiitaArticles() async {
+  // APIのurl
+  const url =
+      'https://qiita.com/api/v2/items?page=1&per_page=20&query=qiita+user%3AQiita';
+  final response = await Dio().get(url);
+  print("response: $response");
+
+  if (response.statusCode == 200) {
+    // null Check
+    if (response.data != null) {
+      List<dynamic> responseDataList;
+      // responseのdataを一旦、dynamic型のListとして格納
+      responseDataList = response.data!['title'] as List<dynamic>;
+    } else {
+      throw Exception('Data is not exist');
+    }
+  } else {
+    throw Exception('Failed to load sentence');
+  }
+
+  var articles = response.data
+      .map((dynamic i) => QiitaArticle.fromJson(i as Map<String, dynamic>))
+      .toList();
+
+  print("articles: $articles");
+
+  return articles;
+}

--- a/lib/model/qiita_article.dart
+++ b/lib/model/qiita_article.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:qiita_application/model/qiita_user.dart';
+
+part 'qiita_article.freezed.dart';
+part 'qiita_article.g.dart';
+
+@freezed
+abstract class QiitaArticle with _$QiitaArticle {
+  factory QiitaArticle({
+    String? title,
+    String? url,
+    QiitaUser? user,
+    List? tags,
+    @JsonKey(name: 'created_at') String? createdAt,
+  }) = _QiitaArticle;
+
+  factory QiitaArticle.fromJson(Map<String, dynamic> json) =>
+      _$QiitaArticleFromJson(json);
+}

--- a/lib/model/qiita_article.freezed.dart
+++ b/lib/model/qiita_article.freezed.dart
@@ -1,0 +1,266 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'qiita_article.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+QiitaArticle _$QiitaArticleFromJson(Map<String, dynamic> json) {
+  return _QiitaArticle.fromJson(json);
+}
+
+/// @nodoc
+mixin _$QiitaArticle {
+  String? get title => throw _privateConstructorUsedError;
+  String? get url => throw _privateConstructorUsedError;
+  QiitaUser? get user => throw _privateConstructorUsedError;
+  List<dynamic>? get tags => throw _privateConstructorUsedError;
+  @JsonKey(name: 'created_at')
+  String? get createdAt => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $QiitaArticleCopyWith<QiitaArticle> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $QiitaArticleCopyWith<$Res> {
+  factory $QiitaArticleCopyWith(
+          QiitaArticle value, $Res Function(QiitaArticle) then) =
+      _$QiitaArticleCopyWithImpl<$Res, QiitaArticle>;
+  @useResult
+  $Res call(
+      {String? title,
+      String? url,
+      QiitaUser? user,
+      List<dynamic>? tags,
+      @JsonKey(name: 'created_at') String? createdAt});
+
+  $QiitaUserCopyWith<$Res>? get user;
+}
+
+/// @nodoc
+class _$QiitaArticleCopyWithImpl<$Res, $Val extends QiitaArticle>
+    implements $QiitaArticleCopyWith<$Res> {
+  _$QiitaArticleCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = freezed,
+    Object? url = freezed,
+    Object? user = freezed,
+    Object? tags = freezed,
+    Object? createdAt = freezed,
+  }) {
+    return _then(_value.copyWith(
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      url: freezed == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+      user: freezed == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as QiitaUser?,
+      tags: freezed == tags
+          ? _value.tags
+          : tags // ignore: cast_nullable_to_non_nullable
+              as List<dynamic>?,
+      createdAt: freezed == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $QiitaUserCopyWith<$Res>? get user {
+    if (_value.user == null) {
+      return null;
+    }
+
+    return $QiitaUserCopyWith<$Res>(_value.user!, (value) {
+      return _then(_value.copyWith(user: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$_QiitaArticleCopyWith<$Res>
+    implements $QiitaArticleCopyWith<$Res> {
+  factory _$$_QiitaArticleCopyWith(
+          _$_QiitaArticle value, $Res Function(_$_QiitaArticle) then) =
+      __$$_QiitaArticleCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? title,
+      String? url,
+      QiitaUser? user,
+      List<dynamic>? tags,
+      @JsonKey(name: 'created_at') String? createdAt});
+
+  @override
+  $QiitaUserCopyWith<$Res>? get user;
+}
+
+/// @nodoc
+class __$$_QiitaArticleCopyWithImpl<$Res>
+    extends _$QiitaArticleCopyWithImpl<$Res, _$_QiitaArticle>
+    implements _$$_QiitaArticleCopyWith<$Res> {
+  __$$_QiitaArticleCopyWithImpl(
+      _$_QiitaArticle _value, $Res Function(_$_QiitaArticle) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = freezed,
+    Object? url = freezed,
+    Object? user = freezed,
+    Object? tags = freezed,
+    Object? createdAt = freezed,
+  }) {
+    return _then(_$_QiitaArticle(
+      title: freezed == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      url: freezed == url
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+      user: freezed == user
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as QiitaUser?,
+      tags: freezed == tags
+          ? _value._tags
+          : tags // ignore: cast_nullable_to_non_nullable
+              as List<dynamic>?,
+      createdAt: freezed == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_QiitaArticle implements _QiitaArticle {
+  _$_QiitaArticle(
+      {this.title,
+      this.url,
+      this.user,
+      final List<dynamic>? tags,
+      @JsonKey(name: 'created_at') this.createdAt})
+      : _tags = tags;
+
+  factory _$_QiitaArticle.fromJson(Map<String, dynamic> json) =>
+      _$$_QiitaArticleFromJson(json);
+
+  @override
+  final String? title;
+  @override
+  final String? url;
+  @override
+  final QiitaUser? user;
+  final List<dynamic>? _tags;
+  @override
+  List<dynamic>? get tags {
+    final value = _tags;
+    if (value == null) return null;
+    if (_tags is EqualUnmodifiableListView) return _tags;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  @JsonKey(name: 'created_at')
+  final String? createdAt;
+
+  @override
+  String toString() {
+    return 'QiitaArticle(title: $title, url: $url, user: $user, tags: $tags, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_QiitaArticle &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.user, user) || other.user == user) &&
+            const DeepCollectionEquality().equals(other._tags, _tags) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, title, url, user,
+      const DeepCollectionEquality().hash(_tags), createdAt);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_QiitaArticleCopyWith<_$_QiitaArticle> get copyWith =>
+      __$$_QiitaArticleCopyWithImpl<_$_QiitaArticle>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_QiitaArticleToJson(
+      this,
+    );
+  }
+}
+
+abstract class _QiitaArticle implements QiitaArticle {
+  factory _QiitaArticle(
+      {final String? title,
+      final String? url,
+      final QiitaUser? user,
+      final List<dynamic>? tags,
+      @JsonKey(name: 'created_at') final String? createdAt}) = _$_QiitaArticle;
+
+  factory _QiitaArticle.fromJson(Map<String, dynamic> json) =
+      _$_QiitaArticle.fromJson;
+
+  @override
+  String? get title;
+  @override
+  String? get url;
+  @override
+  QiitaUser? get user;
+  @override
+  List<dynamic>? get tags;
+  @override
+  @JsonKey(name: 'created_at')
+  String? get createdAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$_QiitaArticleCopyWith<_$_QiitaArticle> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/qiita_article.g.dart
+++ b/lib/model/qiita_article.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'qiita_article.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_QiitaArticle _$$_QiitaArticleFromJson(Map<String, dynamic> json) =>
+    _$_QiitaArticle(
+      title: json['title'] as String?,
+      url: json['url'] as String?,
+      user: json['user'] == null
+          ? null
+          : QiitaUser.fromJson(json['user'] as Map<String, dynamic>),
+      tags: json['tags'] as List<dynamic>?,
+      createdAt: json['created_at'] as String?,
+    );
+
+Map<String, dynamic> _$$_QiitaArticleToJson(_$_QiitaArticle instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'url': instance.url,
+      'user': instance.user,
+      'tags': instance.tags,
+      'created_at': instance.createdAt,
+    };

--- a/lib/model/qiita_user.dart
+++ b/lib/model/qiita_user.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'qiita_user.freezed.dart';
+part 'qiita_user.g.dart';
+
+@freezed
+abstract class QiitaUser with _$QiitaUser {
+  factory QiitaUser({
+    String? id,
+    @JsonKey(name: 'profile_image_url') String? profileImageUrl,
+  }) = _QiitaUser;
+
+  factory QiitaUser.fromJson(Map<String, dynamic> json) =>
+      _$QiitaUserFromJson(json);
+}

--- a/lib/model/qiita_user.freezed.dart
+++ b/lib/model/qiita_user.freezed.dart
@@ -1,0 +1,177 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'qiita_user.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+QiitaUser _$QiitaUserFromJson(Map<String, dynamic> json) {
+  return _QiitaUser.fromJson(json);
+}
+
+/// @nodoc
+mixin _$QiitaUser {
+  String? get id => throw _privateConstructorUsedError;
+  @JsonKey(name: 'profile_image_url')
+  String? get profileImageUrl => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $QiitaUserCopyWith<QiitaUser> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $QiitaUserCopyWith<$Res> {
+  factory $QiitaUserCopyWith(QiitaUser value, $Res Function(QiitaUser) then) =
+      _$QiitaUserCopyWithImpl<$Res, QiitaUser>;
+  @useResult
+  $Res call(
+      {String? id,
+      @JsonKey(name: 'profile_image_url') String? profileImageUrl});
+}
+
+/// @nodoc
+class _$QiitaUserCopyWithImpl<$Res, $Val extends QiitaUser>
+    implements $QiitaUserCopyWith<$Res> {
+  _$QiitaUserCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? profileImageUrl = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String?,
+      profileImageUrl: freezed == profileImageUrl
+          ? _value.profileImageUrl
+          : profileImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_QiitaUserCopyWith<$Res> implements $QiitaUserCopyWith<$Res> {
+  factory _$$_QiitaUserCopyWith(
+          _$_QiitaUser value, $Res Function(_$_QiitaUser) then) =
+      __$$_QiitaUserCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String? id,
+      @JsonKey(name: 'profile_image_url') String? profileImageUrl});
+}
+
+/// @nodoc
+class __$$_QiitaUserCopyWithImpl<$Res>
+    extends _$QiitaUserCopyWithImpl<$Res, _$_QiitaUser>
+    implements _$$_QiitaUserCopyWith<$Res> {
+  __$$_QiitaUserCopyWithImpl(
+      _$_QiitaUser _value, $Res Function(_$_QiitaUser) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? profileImageUrl = freezed,
+  }) {
+    return _then(_$_QiitaUser(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String?,
+      profileImageUrl: freezed == profileImageUrl
+          ? _value.profileImageUrl
+          : profileImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_QiitaUser implements _QiitaUser {
+  _$_QiitaUser(
+      {this.id, @JsonKey(name: 'profile_image_url') this.profileImageUrl});
+
+  factory _$_QiitaUser.fromJson(Map<String, dynamic> json) =>
+      _$$_QiitaUserFromJson(json);
+
+  @override
+  final String? id;
+  @override
+  @JsonKey(name: 'profile_image_url')
+  final String? profileImageUrl;
+
+  @override
+  String toString() {
+    return 'QiitaUser(id: $id, profileImageUrl: $profileImageUrl)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_QiitaUser &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.profileImageUrl, profileImageUrl) ||
+                other.profileImageUrl == profileImageUrl));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, profileImageUrl);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_QiitaUserCopyWith<_$_QiitaUser> get copyWith =>
+      __$$_QiitaUserCopyWithImpl<_$_QiitaUser>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_QiitaUserToJson(
+      this,
+    );
+  }
+}
+
+abstract class _QiitaUser implements QiitaUser {
+  factory _QiitaUser(
+          {final String? id,
+          @JsonKey(name: 'profile_image_url') final String? profileImageUrl}) =
+      _$_QiitaUser;
+
+  factory _QiitaUser.fromJson(Map<String, dynamic> json) =
+      _$_QiitaUser.fromJson;
+
+  @override
+  String? get id;
+  @override
+  @JsonKey(name: 'profile_image_url')
+  String? get profileImageUrl;
+  @override
+  @JsonKey(ignore: true)
+  _$$_QiitaUserCopyWith<_$_QiitaUser> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/qiita_user.g.dart
+++ b/lib/model/qiita_user.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'qiita_user.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_QiitaUser _$$_QiitaUserFromJson(Map<String, dynamic> json) => _$_QiitaUser(
+      id: json['id'] as String?,
+      profileImageUrl: json['profile_image_url'] as String?,
+    );
+
+Map<String, dynamic> _$$_QiitaUserToJson(_$_QiitaUser instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'profile_image_url': instance.profileImageUrl,
+    };

--- a/lib/view/show_search_result_page.dart
+++ b/lib/view/show_search_result_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:qiita_application/ripository.dart';
+import 'package:qiita_application/api/qiita_repository.dart';
 
 class ShowSearchResult extends StatefulWidget {
   const ShowSearchResult({Key? key}) : super(key: key);
@@ -54,7 +54,8 @@ class _ShowSearchResultState extends State<ShowSearchResult> {
         ),
         onTap: () {
           print("$titleがTapされました");
-          fetchParsonDataList();
+          // fetchParsonDataList();
+          fetchQiitaArticles();
         },
         onLongPress: () {
           // 長押し時の処理


### PR DESCRIPTION
修正内容
■Model：
・Qiita Userクラスを作成
・Qiita記事の値を管理する「qiitaArticle」クラスを作成

■api：
・Qiita APIをリクエストし、応答値を出力する